### PR TITLE
Add dev dependencies to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,21 @@ Imports:
 	purrr,
 	zellkonverter,
 	BiocGenerics,
-	glue
-VignetteBuilder: 
+	glue,
+	HDF5Array
+Suggests:
+  glue,
+  here,
+  stringr,
+  Seurat,
+  tidyseurat,
+  scMerge,
+  DelayedArray,
+  openssl,
+  cellxgenedp,
+  SingleCellExperiment,
+  zellkonverter
+VignetteBuilder:
     knitr
 RdMacros:
     lifecycle

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,17 +18,17 @@ Imports:
 	glue,
 	HDF5Array
 Suggests:
-  glue,
-  here,
-  stringr,
-  Seurat,
-  tidyseurat,
-  scMerge,
-  DelayedArray,
-  openssl,
-  cellxgenedp,
-  SingleCellExperiment,
-  zellkonverter
+	glue,
+	here,
+	stringr,
+	Seurat,
+	tidyseurat,
+	scMerge,
+	DelayedArray,
+	openssl,
+	cellxgenedp,
+	SingleCellExperiment,
+	zellkonverter
 VignetteBuilder:
     knitr
 RdMacros:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Imports:
 	glue,
 	HDF5Array
 Suggests:
-	glue,
 	here,
 	stringr,
 	Seurat,
@@ -28,7 +27,10 @@ Suggests:
 	openssl,
 	cellxgenedp,
 	SingleCellExperiment,
-	zellkonverter
+	celldex,
+	SingleR,
+	tools,
+	rmarkdown
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
These are mostly based on the output from `renv::dependencies`. The only one I excluded is `tidyverse` for obvious reasons. Eventually it might be good to replace that with more specific library usage.